### PR TITLE
Lookup errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* 0.2.0 -- Catch and report errors on lookup of records from ids and record to id conversions

--- a/lib/job_metadata/version.rb
+++ b/lib/job_metadata/version.rb
@@ -1,3 +1,3 @@
 module JobMetadata
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/job_metadata/batch_tracker_spec.rb
+++ b/spec/job_metadata/batch_tracker_spec.rb
@@ -169,42 +169,18 @@ module JobMetadata
 
         context 'when the #ids_to_records_conversion throws a StandardError' do
           let(:ids_to_records_conversion) { ->(ids) { raise StandardError.new('bad ids_to_records') } }
-          let(:tracker) do
-            BatchTracker.new(
-              batch: batch,
-              job: job,
-              error_callback: error_callback,
-              ids_to_records: ids_to_records_conversion,
-              record_to_id: record_to_id_conversion
-            )
-          end
-
-          before do
-            expect(rollbar_double).to receive(:error)
-          end
 
           it 'calls the error_callback and re-raises the error' do
+            expect(rollbar_double).to receive(:error)
             expect{ tracker.each_record { |id| id } }.to raise_error(StandardError, 'bad ids_to_records')
           end
         end
 
         context 'when the #record_to_id_conversion throws a StandardError' do
           let(:record_to_id_conversion) { ->(ids) { raise StandardError.new('bad record_to_id') } }
-          let(:tracker) do
-            BatchTracker.new(
-              batch: batch,
-              job: job,
-              error_callback: error_callback,
-              ids_to_records: ids_to_records_conversion,
-              record_to_id: record_to_id_conversion
-            )
-          end
-
-          before do
-            expect(rollbar_double).to receive(:error)
-          end
 
           it 'calls the error_callback and re-raises the error' do
+            expect(rollbar_double).to receive(:error)
             expect{ tracker.each_record { |id| raise StandardError } }.to raise_error(StandardError, 'bad record_to_id')
           end
         end

--- a/spec/job_metadata/job_collection_spec.rb
+++ b/spec/job_metadata/job_collection_spec.rb
@@ -25,7 +25,7 @@ module JobMetadata
 
       it "adds the job to the job_collection's jobs" do
         job = subject
-        expect(job_collection.items_for_set(:jobs).to_a.last).to eq(job.identifier)
+        expect(job_collection.items_for_set(:jobs).to_a).to include(job.identifier)
       end
     end
 
@@ -34,7 +34,7 @@ module JobMetadata
         let!(:job) { job_collection.new_job('test_job_id') }
 
         it 'returns a job object with the matching identifier' do
-          expect(job_collection.all_jobs.last.identifier).to eq(job.identifier)
+          expect(job_collection.all_jobs.map(&:identifier)).to include(job.identifier)
         end
       end
     end

--- a/spec/job_metadata/job_spec.rb
+++ b/spec/job_metadata/job_spec.rb
@@ -19,7 +19,7 @@ module JobMetadata
       end
 
       it 'adds the ids to the pending set of the batch' do
-        expect(subject.items_for_set(:pending).map(&:to_i)).to eq(ids)
+        expect(subject.items_for_set(:pending).map(&:to_i).sort).to eq(ids.sort)
       end
 
       it "adds the batch to the job's batches" do

--- a/spec/job_metadata/redis_client_spec.rb
+++ b/spec/job_metadata/redis_client_spec.rb
@@ -14,7 +14,7 @@ module JobMetadata
 
       it 'adds the items to the set' do
         subject
-        expect(client.items_for_set(set).map(&:to_i)).to eq(ids)
+        expect(client.items_for_set(set).map(&:to_i).sort).to eq(ids.sort)
       end
     end
 
@@ -26,7 +26,7 @@ module JobMetadata
 
         it 'returns the items from the set' do
           subject
-          expect(subject.map(&:to_i)).to eq(ids)
+          expect(subject.map(&:to_i).sort).to eq(ids.sort)
         end
       end
     end


### PR DESCRIPTION
This is the more general solution to https://github.com/lumoslabs/llama-llama-bill/pull/74

Basically, we weren't reporting errors that occured during record lookup, so basically anything happening in the Clerk serializers

Getting this right basically makes error reporting foolproof for any jobmetadata job.